### PR TITLE
Update README to reflect MGRS parsing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ MGRS (Military Grid Reference System)
  * Convert UTM to Lat/Lon
  * Convert USNG to UTM
  * Convert USNG to Lat/Lon
- * Convert Lat/Lon to MGRS
+ * Convert MGRS to USNG


### PR DESCRIPTION
The README stated the ability to convert from Lat/Lon to MGRS, but that does not appear possible. It looks like MGRS is generted from a UsngCoordinate object, which doesn't have a way of parsing Lat/Lon.

Also added converting MGRS to USNG since that is supported and was not reflected.

@brendan-hofmann @andrewkfiedler @dcruver @dimitry-sherman 