### PR TITLE
Fix parsing and precision handling for easting and northing values

### DIFF
--- a/usng4j-api/src/main/java/org/codice/usng4j/CoordinatePrecision.java
+++ b/usng4j-api/src/main/java/org/codice/usng4j/CoordinatePrecision.java
@@ -64,16 +64,16 @@ public enum CoordinatePrecision {
     return this.precisionValue;
   }
 
-  public static CoordinatePrecision forEastNorth(int easting, int northing) {
-    int maxValue = Math.max(easting, northing);
+  public static CoordinatePrecision forEastNorth(String easting, String northing) {
+    int maxLength = Math.max(easting.length(), northing.length());
 
-    if (maxValue > 9999) {
+    if (maxLength > 4) {
       return CoordinatePrecision.ONE_METER;
-    } else if (maxValue > 999) {
+    } else if (maxLength > 3) {
       return CoordinatePrecision.TEN_METERS;
-    } else if (maxValue > 99) {
+    } else if (maxLength > 2) {
       return CoordinatePrecision.ONE_HUNDRED_METERS;
-    } else if (maxValue > 9) {
+    } else if (maxLength > 1) {
       return CoordinatePrecision.ONE_KILOMETER;
     }
 

--- a/usng4j-api/src/main/java/org/codice/usng4j/CoordinatePrecision.java
+++ b/usng4j-api/src/main/java/org/codice/usng4j/CoordinatePrecision.java
@@ -65,7 +65,7 @@ public enum CoordinatePrecision {
   }
 
   public static CoordinatePrecision forEastNorth(String easting, String northing) {
-    int maxLength = Math.max(easting.length(), northing.length());
+    int maxLength = Math.max(easting.trim().length(), northing.trim().length());
 
     if (maxLength > 4) {
       return CoordinatePrecision.ONE_METER;

--- a/usng4j-api/src/main/java/org/codice/usng4j/UsngCoordinate.java
+++ b/usng4j-api/src/main/java/org/codice/usng4j/UsngCoordinate.java
@@ -59,7 +59,7 @@ public interface UsngCoordinate {
   public final String USNG_COORDINATE_PART_REGEX_STRING = "(\\W\\d{0,5})?(\\W\\d{0,5})?";
 
   /** RegEx expressions for MGRS Northing and Easting parsing */
-  public final String MGRS_COORDINATE_PART_REGEX_STRING = "(\\d{0,5})\\W*(\\d{0,5})\\W*";
+  public final String MGRS_COORDINATE_PART_REGEX_STRING = "(\\d{0,12})\\W*";
 
   /** @return the zone number of this USNG coordinate. */
   int getZoneNumber();

--- a/usng4j-api/src/main/java/org/codice/usng4j/UsngCoordinate.java
+++ b/usng4j-api/src/main/java/org/codice/usng4j/UsngCoordinate.java
@@ -56,7 +56,7 @@ public interface UsngCoordinate {
           + ")?";
 
   /** RegEx expressions for USNG Northing and Easting parsing */
-  public final String USNG_COORDINATE_PART_REGEX_STRING = "(\\W\\d{0,5})?(\\W\\d{0,5})?";
+  public final String USNG_COORDINATE_PART_REGEX_STRING = "([\\d|\\s]{0,12})";
 
   /** RegEx expressions for MGRS Northing and Easting parsing */
   public final String MGRS_COORDINATE_PART_REGEX_STRING = "(\\d{0,10})";

--- a/usng4j-api/src/main/java/org/codice/usng4j/UsngCoordinate.java
+++ b/usng4j-api/src/main/java/org/codice/usng4j/UsngCoordinate.java
@@ -59,7 +59,7 @@ public interface UsngCoordinate {
   public final String USNG_COORDINATE_PART_REGEX_STRING = "(\\W\\d{0,5})?(\\W\\d{0,5})?";
 
   /** RegEx expressions for MGRS Northing and Easting parsing */
-  public final String MGRS_COORDINATE_PART_REGEX_STRING = "(\\d{0,12})\\W*";
+  public final String MGRS_COORDINATE_PART_REGEX_STRING = "(\\d{0,10})";
 
   /** @return the zone number of this USNG coordinate. */
   int getZoneNumber();

--- a/usng4j-impl/src/main/java/org/codice/usng4j/impl/CoordinateSystemTranslatorImpl.java
+++ b/usng4j-impl/src/main/java/org/codice/usng4j/impl/CoordinateSystemTranslatorImpl.java
@@ -894,7 +894,8 @@ public final class CoordinateSystemTranslatorImpl implements CoordinateSystemTra
                 Optional.ofNullable(usngCoordinate.getColumnLetter()).orElse((char) 0),
                 Optional.ofNullable(usngCoordinate.getRowLetter()).orElse((char) 0),
                 Optional.ofNullable(usngCoordinate.getEasting()).orElse(0),
-                Optional.ofNullable(usngCoordinate.getNorthing()).orElse(0)));
+                Optional.ofNullable(usngCoordinate.getNorthing()).orElse(0),
+                usngCoordinate.getPrecision()));
 
     double northing = coords.getNorthing();
 

--- a/usng4j-impl/src/main/java/org/codice/usng4j/impl/UsngCoordinateImpl.java
+++ b/usng4j-impl/src/main/java/org/codice/usng4j/impl/UsngCoordinateImpl.java
@@ -215,8 +215,8 @@ final class UsngCoordinateImpl implements UsngCoordinate {
       char columnLetter = m.group(3).toCharArray()[0];
       char rowLetter = m.group(3).toCharArray()[1];
 
-      if (captureGroupsCount > 4 &&
-          !(StringUtils.isEmpty(m.group(4)) || StringUtils.isEmpty(m.group(5)))) {
+      if (captureGroupsCount > 4
+          && !(StringUtils.isEmpty(m.group(4)) || StringUtils.isEmpty(m.group(5)))) {
         String easting = m.group(4).trim();
         String northing = m.group(5).trim();
         int eastingInt = Integer.parseInt(easting);
@@ -238,7 +238,12 @@ final class UsngCoordinateImpl implements UsngCoordinate {
 
         result =
             new UsngCoordinateImpl(
-                zoneNumber, latitudeBandLetter, columnLetter, rowLetter, eastingInt, northingInt,
+                zoneNumber,
+                latitudeBandLetter,
+                columnLetter,
+                rowLetter,
+                eastingInt,
+                northingInt,
                 precision);
       } else {
         result = new UsngCoordinateImpl(zoneNumber, latitudeBandLetter, columnLetter, rowLetter);

--- a/usng4j-impl/src/main/java/org/codice/usng4j/impl/UtmCoordinateImpl.java
+++ b/usng4j-impl/src/main/java/org/codice/usng4j/impl/UtmCoordinateImpl.java
@@ -59,7 +59,8 @@ final class UtmCoordinateImpl implements UtmCoordinate {
     this.zoneNumber = zoneNumber;
     this.easting = easting;
     this.northing = northing;
-    this.precision = CoordinatePrecision.forEastNorth((int) easting, (int) northing);
+    this.precision =
+        CoordinatePrecision.forEastNorth(Double.toString(easting), Double.toString(northing));
     this.nsIndicator = NORTH;
   }
 

--- a/usng4j-impl/src/main/java/org/codice/usng4j/impl/UtmUpsCoordinateImpl.java
+++ b/usng4j-impl/src/main/java/org/codice/usng4j/impl/UtmUpsCoordinateImpl.java
@@ -95,7 +95,8 @@ public class UtmUpsCoordinateImpl implements UtmUpsCoordinate {
     this.easting = easting;
     this.northing = northing;
     this.nsIndicator = nsIndicator;
-    this.precision = CoordinatePrecision.forEastNorth((int) easting, (int) northing);
+    this.precision =
+        CoordinatePrecision.forEastNorth(Double.toString(easting), Double.toString(northing));
   }
 
   static UtmUpsCoordinate fromZoneBandEastingNorthingNSI(

--- a/usng4j-impl/src/test/java/org/codice/usng4j/impl/CoordinateSystemTranslatorTest.java
+++ b/usng4j-impl/src/test/java/org/codice/usng4j/impl/CoordinateSystemTranslatorTest.java
@@ -434,11 +434,11 @@ public class CoordinateSystemTranslatorTest extends BaseClassForUsng4jTest {
     char sq1 = 'U';
     char sq2 = 'J';
     int easting = 23487;
-    int northing = 6483;
+    int northing = 64830;
     UtmCoordinate coords =
         coordinateSystemTranslator.toUtm(
             new UsngCoordinateImpl(zone, letter, sq1, sq2, easting, northing));
-    assertEquals(4306483, Math.floor(coords.getNorthing()), 0);
+    assertEquals(4364830, Math.floor(coords.getNorthing()), 0);
     assertEquals(323487, Math.floor(coords.getEasting()), 0);
     assertEquals(18, coords.getZoneNumber());
     assertEquals('S', coords.getLattitudeBand().charValue());

--- a/usng4j-impl/src/test/java/org/codice/usng4j/impl/CoordinateSystemTranslatorTest.java
+++ b/usng4j-impl/src/test/java/org/codice/usng4j/impl/CoordinateSystemTranslatorTest.java
@@ -233,6 +233,39 @@ public class CoordinateSystemTranslatorTest extends BaseClassForUsng4jTest {
     assertEquals(43292, parts.getNorthing(), 0);
   }
 
+  @Test(expected = ParseException.class)
+  public void testUsngStringUnequalEastingNorthingLengths() throws ParseException {
+    String usngString = "12R WA 6958 026";
+    UsngCoordinateImpl.parseUsngString(usngString);
+  }
+
+  @Test(expected = ParseException.class)
+  public void testMgrsStringUnequalEastingNorthingLengths() throws ParseException {
+    String mgrsString = "12RWA69580";
+    UsngCoordinateImpl.parseMgrsString(mgrsString);
+  }
+
+  @Test
+  public void testUsngConversionToMgrs() throws ParseException {
+    String usngString = "12R WA 6958 0265";
+    UsngCoordinate usngCoord = UsngCoordinateImpl.parseUsngString(usngString);
+    String convertedToMgrs = usngCoord.toMgrsString();
+    String expectedMgrsString = "12RWA69580265";
+    assertEquals(expectedMgrsString, convertedToMgrs);
+
+    usngString = "12R WA 0058 0265";
+    usngCoord = UsngCoordinateImpl.parseUsngString(usngString);
+    convertedToMgrs = usngCoord.toMgrsString();
+    expectedMgrsString = "12RWA00580265";
+    assertEquals(expectedMgrsString, convertedToMgrs);
+
+    usngString = "12R WA 9 2";
+    usngCoord = UsngCoordinateImpl.parseUsngString(usngString);
+    convertedToMgrs = usngCoord.toMgrsString();
+    expectedMgrsString = "12RWA92";
+    assertEquals(expectedMgrsString, convertedToMgrs);
+  }
+
   @Test
   public void testMgrsConversionConsistency() throws ParseException {
     // a MGRS string converted to a USNG coordinate and converted back to MGRS should be unchanged

--- a/usng4j-impl/src/test/java/org/codice/usng4j/impl/CoordinateSystemTranslatorTest.java
+++ b/usng4j-impl/src/test/java/org/codice/usng4j/impl/CoordinateSystemTranslatorTest.java
@@ -270,8 +270,8 @@ public class CoordinateSystemTranslatorTest extends BaseClassForUsng4jTest {
     String onlineUTMString = "12R 569580 3502650";
     UtmCoordinate onlineUtmCoord = coordinateSystemTranslator.parseUtmString(onlineUTMString);
     assertEquals(onlineUtmCoord.getZoneNumber(), utmCoord.getZoneNumber());
-    assertEquals(onlineUtmCoord.getLatitudeBand().charValue(),
-          utmCoord.getLatitudeBand().charValue());
+    assertEquals(
+        onlineUtmCoord.getLatitudeBand().charValue(), utmCoord.getLatitudeBand().charValue());
     assertEquals(onlineUtmCoord.getEasting(), utmCoord.getEasting(), 0);
     assertEquals(onlineUtmCoord.getNorthing(), utmCoord.getNorthing(), 0);
     assertEquals(onlineUtmCoord.getPrecision(), utmCoord.getPrecision());
@@ -282,8 +282,8 @@ public class CoordinateSystemTranslatorTest extends BaseClassForUsng4jTest {
     onlineUTMString = "12R 500580 3500650";
     onlineUtmCoord = coordinateSystemTranslator.parseUtmString(onlineUTMString);
     assertEquals(onlineUtmCoord.getZoneNumber(), utmCoord.getZoneNumber());
-    assertEquals(onlineUtmCoord.getLatitudeBand().charValue(),
-        utmCoord.getLatitudeBand().charValue());
+    assertEquals(
+        onlineUtmCoord.getLatitudeBand().charValue(), utmCoord.getLatitudeBand().charValue());
     assertEquals(onlineUtmCoord.getEasting(), utmCoord.getEasting(), 0);
     assertEquals(onlineUtmCoord.getNorthing(), utmCoord.getNorthing(), 0);
     assertEquals(onlineUtmCoord.getPrecision(), utmCoord.getPrecision());

--- a/usng4j-impl/src/test/java/org/codice/usng4j/impl/CoordinateSystemTranslatorTest.java
+++ b/usng4j-impl/src/test/java/org/codice/usng4j/impl/CoordinateSystemTranslatorTest.java
@@ -233,6 +233,122 @@ public class CoordinateSystemTranslatorTest extends BaseClassForUsng4jTest {
     assertEquals(43292, parts.getNorthing(), 0);
   }
 
+  @Test
+  public void testMgrsConversionConsistency() throws ParseException {
+    // a MGRS string converted to a USNG coordinate and converted back to MGRS should be unchanged
+
+    String mgrsString = "12RWA69580265";
+    UsngCoordinate usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    String convertedToMgrs = usngCoord.toMgrsString();
+    assertEquals(mgrsString, convertedToMgrs);
+
+    mgrsString = "12RWA00580065";
+    usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    convertedToMgrs = usngCoord.toMgrsString();
+    assertEquals(mgrsString, convertedToMgrs);
+
+    mgrsString = "12RWA92";
+    usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    convertedToMgrs = usngCoord.toMgrsString();
+    assertEquals(mgrsString, convertedToMgrs);
+
+    mgrsString = "12RWA0000200006";
+    usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    convertedToMgrs = usngCoord.toMgrsString();
+    assertEquals(mgrsString, convertedToMgrs);
+  }
+
+  @Test
+  public void testMgrsUTMConversionWithOnline() throws ParseException {
+    // a MGRS to a UTM coordinate should be consistent with a chosen online source
+    // (http://www.earthpoint.us)
+
+    String mgrsString = "12RWA69580265";
+    UsngCoordinate usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    UtmCoordinate utmCoord = coordinateSystemTranslator.toUtm(usngCoord);
+    // converted MGRS string from online source (http://www.earthpoint.us/Convert.aspx)
+    String onlineUTMString = "12R 569580 3502650";
+    UtmCoordinate onlineUtmCoord = coordinateSystemTranslator.parseUtmString(onlineUTMString);
+    assertEquals(onlineUtmCoord.getZoneNumber(), utmCoord.getZoneNumber());
+    assertEquals(onlineUtmCoord.getLatitudeBand().charValue(),
+          utmCoord.getLatitudeBand().charValue());
+    assertEquals(onlineUtmCoord.getEasting(), utmCoord.getEasting(), 0);
+    assertEquals(onlineUtmCoord.getNorthing(), utmCoord.getNorthing(), 0);
+    assertEquals(onlineUtmCoord.getPrecision(), utmCoord.getPrecision());
+
+    mgrsString = "12RWA00580065";
+    usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    utmCoord = coordinateSystemTranslator.toUtm(usngCoord);
+    onlineUTMString = "12R 500580 3500650";
+    onlineUtmCoord = coordinateSystemTranslator.parseUtmString(onlineUTMString);
+    assertEquals(onlineUtmCoord.getZoneNumber(), utmCoord.getZoneNumber());
+    assertEquals(onlineUtmCoord.getLatitudeBand().charValue(),
+        utmCoord.getLatitudeBand().charValue());
+    assertEquals(onlineUtmCoord.getEasting(), utmCoord.getEasting(), 0);
+    assertEquals(onlineUtmCoord.getNorthing(), utmCoord.getNorthing(), 0);
+    assertEquals(onlineUtmCoord.getPrecision(), utmCoord.getPrecision());
+  }
+
+  @Test
+  public void testMgrsLatLonWithOnline() throws ParseException {
+    // a MGRS to a latitude/longitude coordinate should be consistent with a chosen online source
+    // (http://www.earthpoint.us)
+
+    String mgrsString = "12RWA69580265";
+    UsngCoordinate usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    DecimalDegreesCoordinate latLon = coordinateSystemTranslator.toLatLon(usngCoord);
+    double onlineLatitude = 31.6569851;
+    double onlineLongitude = -110.2660838;
+    assertLatOrLonIsClose(true, onlineLatitude, latLon.getLat());
+    assertLatOrLonIsClose(false, onlineLongitude, latLon.getLon());
+
+    mgrsString = "12RWA00580065";
+    usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    latLon = coordinateSystemTranslator.toLatLon(usngCoord);
+    onlineLatitude = 31.6410506;
+    onlineLongitude = -110.9938832;
+    assertLatOrLonIsClose(true, onlineLatitude, latLon.getLat());
+    assertLatOrLonIsClose(false, onlineLongitude, latLon.getLon());
+
+    mgrsString = "12RWA92";
+    usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    latLon = coordinateSystemTranslator.toLatLon(usngCoord);
+    onlineLatitude = 31.8120783;
+    onlineLongitude = -110.0491227;
+    assertLatOrLonIsClose(true, onlineLatitude, latLon.getLat());
+    assertLatOrLonIsClose(false, onlineLongitude, latLon.getLon());
+
+    mgrsString = "12RWA0000200006";
+    usngCoord = UsngCoordinateImpl.parseMgrsString(mgrsString);
+    latLon = coordinateSystemTranslator.toLatLon(usngCoord);
+    onlineLatitude = 31.6352404;
+    onlineLongitude = -110.9999789;
+    assertLatOrLonIsClose(true, onlineLatitude, latLon.getLat());
+    assertLatOrLonIsClose(false, onlineLongitude, latLon.getLon());
+  }
+
+  @Test
+  public void testUtmLatLongWithOnline() throws ParseException {
+    // a UTM to a latitude/longitude coordinate should be consistent with a chosen online source
+    // (http://www.earthpoint.us)
+
+    String utmString = "19T 330395 4691720";
+    UtmCoordinate utmCoord = UtmCoordinateImpl.parseUtmString(utmString);
+    DecimalDegreesCoordinate latLon = coordinateSystemTranslator.toLatLon(utmCoord);
+    double onlineLatitude = 42.3592599;
+    double onlineLongitude = -071.0595174;
+    assertLatOrLonIsClose(true, onlineLatitude, latLon.getLat());
+    assertLatOrLonIsClose(false, onlineLongitude, latLon.getLon());
+
+    utmString = "19T 318612 4705686";
+    utmCoord = UtmCoordinateImpl.parseUtmString(utmString);
+    latLon = coordinateSystemTranslator.toLatLon(utmCoord);
+    onlineLatitude = 42.4822858;
+    onlineLongitude = -071.2069045;
+    assertLatOrLonIsClose(true, onlineLatitude, latLon.getLat());
+    assertLatOrLonIsClose(false, onlineLongitude, latLon.getLon());
+  }
+
   @Test(expected = ParseException.class)
   public void testFailingUsngParsingWithZonesAboveSixty() throws ParseException {
     UsngCoordinateImpl.parseUsngString("61Q");


### PR DESCRIPTION
## Changes

- Regex for parsing easting and northing values of MGRS coordinates to be able to split them into equal length strings
- Precision determination to handle easting and northing values containing leading zeros

Fixes #17 
@brendan-hofmann @mcalcote @figliold @josephthweatt @dcruver @dimitry-sherman 